### PR TITLE
Add dedicated port for when tests are being run

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -1,2 +1,4 @@
 export default {}
-export const API_URL = 'http://localhost:3000/api'
+const PORT = window.Cypress ? '3001' : '3000'
+
+export const API_URL = `http://localhost:${PORT}/api`


### PR DESCRIPTION
- When the app is running under Cypress, the API port is 3001, otherwise it's 3000. 